### PR TITLE
Adding Structured Logging

### DIFF
--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import re
+from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
@@ -20,6 +21,7 @@ from fabric_cicd._common._exceptions import InputError, ParameterFileError, Pars
 from fabric_cicd._common._fabric_endpoint import FabricEndpoint
 from fabric_cicd._common._item import Item
 from fabric_cicd._common._logging import print_header
+from fabric_cicd.publish_log_entry import PublishLogEntry
 
 logger = logging.getLogger(__name__)
 
@@ -127,6 +129,7 @@ class FabricWorkspace:
         self.repository_items = {}
         self.deployed_folders = {}
         self.deployed_items = {}
+        self.publish_log_entries: list[PublishLogEntry] = []
 
         # temporarily support base_api_url until deprecated
         if "base_api_url" in kwargs:
@@ -515,6 +518,18 @@ class FabricWorkspace:
         # skip_publish_logging provided in kwargs to suppress logging if further processing is to be done
         if not kwargs.get("skip_publish_logging", False):
             logger.info(f"{constants.INDENT}Published")
+
+        self.publish_log_entries.append(
+            PublishLogEntry(
+                name=item_name,
+                item_type=item_type,
+                success=True,
+                error=None,
+                start_time=datetime.now(),
+                end_time=datetime.now(),
+            )
+        )
+
         return
 
     def _unpublish_item(self, item_name: str, item_type: str) -> None:

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -56,6 +56,7 @@ def publish_all_items(fabric_workspace_obj: FabricWorkspace, item_name_exclude_r
 
     fabric_workspace_obj._refresh_deployed_items()
     fabric_workspace_obj._refresh_repository_items()
+    fabric_workspace_obj.publish_log_entries = []
 
     if item_name_exclude_regex:
         logger.warning(
@@ -63,71 +64,78 @@ def publish_all_items(fabric_workspace_obj: FabricWorkspace, item_name_exclude_r
         )
         fabric_workspace_obj.publish_item_name_exclude_regex = item_name_exclude_regex
 
-    if "VariableLibrary" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Publishing Variable Libraries")
-        items.publish_variablelibraries(fabric_workspace_obj)
-    if "Warehouse" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Publishing Warehouses")
-        items.publish_warehouses(fabric_workspace_obj)
-    if "Lakehouse" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Publishing Lakehouses")
-        items.publish_lakehouses(fabric_workspace_obj)
-    if "SQLDatabase" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Publishing SQL Databases")
-        items.publish_sqldatabases(fabric_workspace_obj)
-    if "MirroredDatabase" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Publishing Mirrored Databases")
-        items.publish_mirroreddatabase(fabric_workspace_obj)
-    if "Environment" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Publishing Environments")
-        items.publish_environments(fabric_workspace_obj)
-    if "Notebook" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Publishing Notebooks")
-        items.publish_notebooks(fabric_workspace_obj)
-    if "SemanticModel" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Publishing Semantic Models")
-        items.publish_semanticmodels(fabric_workspace_obj)
-    if "Report" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Publishing Reports")
-        items.publish_reports(fabric_workspace_obj)
-    if "CopyJob" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Publishing Copy Jobs")
-        items.publish_copyjobs(fabric_workspace_obj)
-    if "Eventhouse" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Publishing Eventhouses")
-        items.publish_eventhouses(fabric_workspace_obj)
-    if "KQLDatabase" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Publishing KQL Databases")
-        items.publish_kqldatabases(fabric_workspace_obj)
-    if "KQLQueryset" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Publishing KQL Querysets")
-        items.publish_kqlquerysets(fabric_workspace_obj)
-    if "Reflex" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Publishing Activators")
-        items.publish_activators(fabric_workspace_obj)
-    if "Eventstream" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Publishing Eventstreams")
-        items.publish_eventstreams(fabric_workspace_obj)
-    if "KQLDashboard" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Publishing KQL Dashboards")
-        items.publish_kqldashboard(fabric_workspace_obj)
-    if "Dataflow" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Publishing Dataflows")
-        items.publish_dataflows(fabric_workspace_obj)
-    if "DataPipeline" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Publishing Data Pipelines")
-        items.publish_datapipelines(fabric_workspace_obj)
-    if "GraphQLApi" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Publishing GraphQL APIs")
-        logger.warning(
-            "Only user authentication is supported for GraphQL API items sourced from SQL Analytics Endpoint"
-        )
-        items.publish_graphqlapis(fabric_workspace_obj)
+    try:
+        if "VariableLibrary" in fabric_workspace_obj.item_type_in_scope:
+            print_header("Publishing Variable Libraries")
+            items.publish_variablelibraries(fabric_workspace_obj)
+        if "Warehouse" in fabric_workspace_obj.item_type_in_scope:
+            print_header("Publishing Warehouses")
+            items.publish_warehouses(fabric_workspace_obj)
+        if "Lakehouse" in fabric_workspace_obj.item_type_in_scope:
+            print_header("Publishing Lakehouses")
+            items.publish_lakehouses(fabric_workspace_obj)
+        if "SQLDatabase" in fabric_workspace_obj.item_type_in_scope:
+            print_header("Publishing SQL Databases")
+            items.publish_sqldatabases(fabric_workspace_obj)
+        if "MirroredDatabase" in fabric_workspace_obj.item_type_in_scope:
+            print_header("Publishing Mirrored Databases")
+            items.publish_mirroreddatabase(fabric_workspace_obj)
+        if "Environment" in fabric_workspace_obj.item_type_in_scope:
+            print_header("Publishing Environments")
+            items.publish_environments(fabric_workspace_obj)
+        if "Notebook" in fabric_workspace_obj.item_type_in_scope:
+            print_header("Publishing Notebooks")
+            items.publish_notebooks(fabric_workspace_obj)
+        if "SemanticModel" in fabric_workspace_obj.item_type_in_scope:
+            print_header("Publishing Semantic Models")
+            items.publish_semanticmodels(fabric_workspace_obj)
+        if "Report" in fabric_workspace_obj.item_type_in_scope:
+            print_header("Publishing Reports")
+            items.publish_reports(fabric_workspace_obj)
+        if "CopyJob" in fabric_workspace_obj.item_type_in_scope:
+            print_header("Publishing Copy Jobs")
+            items.publish_copyjobs(fabric_workspace_obj)
+        if "Eventhouse" in fabric_workspace_obj.item_type_in_scope:
+            print_header("Publishing Eventhouses")
+            items.publish_eventhouses(fabric_workspace_obj)
+        if "KQLDatabase" in fabric_workspace_obj.item_type_in_scope:
+            print_header("Publishing KQL Databases")
+            items.publish_kqldatabases(fabric_workspace_obj)
+        if "KQLQueryset" in fabric_workspace_obj.item_type_in_scope:
+            print_header("Publishing KQL Querysets")
+            items.publish_kqlquerysets(fabric_workspace_obj)
+        if "Reflex" in fabric_workspace_obj.item_type_in_scope:
+            print_header("Publishing Activators")
+            items.publish_activators(fabric_workspace_obj)
+        if "Eventstream" in fabric_workspace_obj.item_type_in_scope:
+            print_header("Publishing Eventstreams")
+            items.publish_eventstreams(fabric_workspace_obj)
+        if "KQLDashboard" in fabric_workspace_obj.item_type_in_scope:
+            print_header("Publishing KQL Dashboards")
+            items.publish_kqldashboard(fabric_workspace_obj)
+        if "Dataflow" in fabric_workspace_obj.item_type_in_scope:
+            print_header("Publishing Dataflows")
+            items.publish_dataflows(fabric_workspace_obj)
+        if "DataPipeline" in fabric_workspace_obj.item_type_in_scope:
+            print_header("Publishing Data Pipelines")
+            items.publish_datapipelines(fabric_workspace_obj)
+        if "GraphQLApi" in fabric_workspace_obj.item_type_in_scope:
+            print_header("Publishing GraphQL APIs")
+            logger.warning(
+                "Only user authentication is supported for GraphQL API items sourced from SQL Analytics Endpoint"
+            )
+            items.publish_graphqlapis(fabric_workspace_obj)
 
-    # Check Environment Publish
-    if "Environment" in fabric_workspace_obj.item_type_in_scope:
-        print_header("Checking Environment Publish State")
-        items.check_environment_publish_state(fabric_workspace_obj)
+        # Check Environment Publish
+        if "Environment" in fabric_workspace_obj.item_type_in_scope:
+            print_header("Checking Environment Publish State")
+            items.check_environment_publish_state(fabric_workspace_obj)
+
+    except Exception as e:
+        logger.error(f"An error occurred during publishing: {e}")
+        return fabric_workspace_obj.publish_log_entries
+
+    return fabric_workspace_obj.publish_log_entries
 
 
 def unpublish_all_orphan_items(fabric_workspace_obj: FabricWorkspace, item_name_exclude_regex: str = "^$") -> None:

--- a/src/fabric_cicd/publish_log_entry.py
+++ b/src/fabric_cicd/publish_log_entry.py
@@ -1,0 +1,30 @@
+"""
+PublishLogEntry dataclass for logging published items in a Fabric workspace.
+This dataclass captures the details of each published item, including its name,
+type, success status, any error messages, and timestamps for when the publish
+operation started and ended.
+"""
+
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass
+class PublishLogEntry:
+    """Dataclass to represent a log entry for published items."""
+
+    name: str
+    item_type: str
+    success: bool
+    error: Optional[str]
+    start_time: datetime
+    end_time: datetime
+
+    def to_dict(self) -> dict:
+        """Convert the PublishLogEntry to a dictionary."""
+        d = asdict(self)
+        # convert datetimes to ISO strings for JSON friendliness
+        d["start_time"] = self.start_time.isoformat()
+        d["end_time"] = self.end_time.isoformat()
+        return d


### PR DESCRIPTION
This pull request introduces a logging mechanism for tracking the publishing process of items in a Fabric workspace. The changes include the addition of a new `PublishLogEntry` dataclass, updates to the `FabricWorkspace` class to store log entries, and modifications to the publishing workflow to handle logging and error reporting.

### Logging Enhancements:
* **New `PublishLogEntry` Dataclass**: Added a `PublishLogEntry` dataclass in `src/fabric_cicd/publish_log_entry.py` to capture details of published items, including name, type, success status, errors, and timestamps. Includes a `to_dict` method for serialization.
* **Log Storage in `FabricWorkspace`**: Introduced a `publish_log_entries` attribute in the `FabricWorkspace` class to store a list of `PublishLogEntry` instances.

### Publishing Workflow Updates:
* **Logging Published Items**: Updated the `_publish_item` method in `FabricWorkspace` to create and append `PublishLogEntry` instances for each published item.
* **Error Handling in `publish_all_items`**: Modified the `publish_all_items` function to clear `publish_log_entries` at the start, handle exceptions during publishing, and return the log entries in case of errors or successful completion. [[1]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R59-R67) [[2]](diffhunk://#diff-a8555a82747092e8d1f2ee36f31c947b4e5a264ed6c6d8de48d8daf850372704R134-R139)## Description


