### PR TITLE
Resolves #365: Ability to feed list of items to be published

### DIFF
--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -8,7 +8,7 @@ import logging
 import os
 import re
 from pathlib import Path
-from typing import List, Optional
+from typing import Optional
 
 import dpath
 from azure.core.credentials import TokenCredential

--- a/src/fabric_cicd/fabric_workspace.py
+++ b/src/fabric_cicd/fabric_workspace.py
@@ -8,7 +8,7 @@ import logging
 import os
 import re
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 import dpath
 from azure.core.credentials import TokenCredential
@@ -123,6 +123,7 @@ class FabricWorkspace:
         self.item_type_in_scope = validate_item_type_in_scope(item_type_in_scope, upn_auth=self.endpoint.upn_auth)
         self.environment = validate_environment(environment)
         self.publish_item_name_exclude_regex = None
+        self.publish_items_to_include = None
         self.repository_folders = {}
         self.repository_items = {}
         self.deployed_folders = {}
@@ -431,6 +432,22 @@ class FabricWorkspace:
                 logger.info(f"Skipping publishing of {item_type} '{item_name}' due to exclusion regex.")
                 return
 
+        # Skip publishing if the item is not in the include list
+        if self.publish_items_to_include:
+            # Normalize include list to a lowercase set for efficient lookups
+            normalized_include_set = {include_item.lower() for include_item in self.publish_items_to_include}
+            
+            # Check for exact match or case-insensitive match
+            match_found = (
+                item_name in self.publish_items_to_include or 
+                item_name.lower() in normalized_include_set
+            )
+            
+            if not match_found:
+                item.skip_publish = True
+                logger.info(f"Skipping publishing of {item_type} '{item_name}' as it is not in the items to include list.")
+                return
+            
         item_guid = item.guid
         item_files = item.item_files
 

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -4,7 +4,7 @@
 """Module for publishing and unpublishing Fabric workspace items."""
 
 import logging
-from typing import Optional
+from typing import List, Optional
 
 import fabric_cicd._items as items
 from fabric_cicd import constants
@@ -18,13 +18,17 @@ from fabric_cicd.fabric_workspace import FabricWorkspace
 logger = logging.getLogger(__name__)
 
 
-def publish_all_items(fabric_workspace_obj: FabricWorkspace, item_name_exclude_regex: Optional[str] = None) -> None:
+def publish_all_items(
+        fabric_workspace_obj: FabricWorkspace, 
+        item_name_exclude_regex: Optional[str] = None,
+        items_to_include: Optional[List[str]] = None) -> None:
     """
     Publishes all items defined in the `item_type_in_scope` list of the given FabricWorkspace object.
 
     Args:
         fabric_workspace_obj: The FabricWorkspace object containing the items to be published.
         item_name_exclude_regex: Regex pattern to exclude specific items from being published.
+        items_to_include: List of specific item names to include. If provided, only these items will be published.
 
 
     Examples:
@@ -46,6 +50,15 @@ def publish_all_items(fabric_workspace_obj: FabricWorkspace, item_name_exclude_r
         ... )
         >>> exclude_regex = ".*_do_not_publish"
         >>> publish_all_items(workspace, exclude_regex)
+        
+        With specific items to include
+        >>> workspace = FabricWorkspace(
+        ...     workspace_id="your-workspace-id",
+        ...     repository_directory="/path/to/repo",
+        ...     item_type_in_scope=["Environment", "Notebook", "DataPipeline"]
+        ... )
+        >>> items_to_include = ["Notebook", "Environment"]
+        >>> publish_all_items(workspace, items_to_include)
     """
     fabric_workspace_obj = validate_fabric_workspace_obj(fabric_workspace_obj)
 
@@ -62,6 +75,10 @@ def publish_all_items(fabric_workspace_obj: FabricWorkspace, item_name_exclude_r
             "Using item_name_exclude_regex is risky as it can prevent needed dependencies from being deployed.  Use at your own risk."
         )
         fabric_workspace_obj.publish_item_name_exclude_regex = item_name_exclude_regex
+        
+    if items_to_include:
+        logger.info(f"Publishing only specified items: {items_to_include}")
+        fabric_workspace_obj.publish_items_to_include = items_to_include
 
     if "VariableLibrary" in fabric_workspace_obj.item_type_in_scope:
         print_header("Publishing Variable Libraries")

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -4,7 +4,7 @@
 """Module for publishing and unpublishing Fabric workspace items."""
 
 import logging
-from typing import List, Optional
+from typing import Optional
 
 import fabric_cicd._items as items
 from fabric_cicd import constants
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 def publish_all_items(
         fabric_workspace_obj: FabricWorkspace, 
         item_name_exclude_regex: Optional[str] = None,
-        items_to_include: Optional[List[str]] = None) -> None:
+        items_to_include: Optional[list[str]] = None) -> None:
     """
     Publishes all items defined in the `item_type_in_scope` list of the given FabricWorkspace object.
 

--- a/src/fabric_cicd/publish.py
+++ b/src/fabric_cicd/publish.py
@@ -76,6 +76,7 @@ def publish_all_items(
         )
         fabric_workspace_obj.publish_item_name_exclude_regex = item_name_exclude_regex
         
+    # Set items to include filter
     if items_to_include:
         logger.info(f"Publishing only specified items: {items_to_include}")
         fabric_workspace_obj.publish_items_to_include = items_to_include


### PR DESCRIPTION
## Description:
This pull request introduces selective publishing capabilities through an items-to-include filter that allows users to specify exactly which items they want to publish. The implementation provides granular control over deployment processes by enabling whitelist-based item selection with case-insensitive matching and efficient lookup performance.

## Branch Context:
This branch was created from main and contains enhancement code developed independently. The target branch already includes initial updates, which may result in merge conflicts during the PR process. These conflicts are expected and will be resolved during the merge review.

## Key Features:

1. Selective Publishing: Users can now specify exactly which items to publish using a whitelist approach
2. Case-Insensitive Matching: Supports both exact and case-insensitive item name matching for user convenience
3. Efficient Lookups: Uses normalized sets for O(1) lookup performance
4. Comprehensive Logging: Provides clear feedback about which items are being skipped
5. Backward Compatibility: The new parameter is optional, maintaining existing API compatibility
6. Combined Filtering: Works alongside the existing exclusion regex functionality

## Key Improvements (Breakdown)

### 1. Import Type Support in Both Modules
 - Added `List` to support the new parameter type and maintain type safety.

### 2. Core Implementation in `fabric_workspace.py`
  - **Added Instance Variable**:
    - self.publish_items_to_include = None - Stores the list of items to include during publishing operations.
  - **Enhanced Publishing Selection:**
    - Normalized Set Creation:
      - Purpose: Creates a lowercase version of all include items for case-insensitive matching
      - Performance: Set comprehension provides O(1) lookup time complexity
    - Dual Matching Strategy:
      - Exact Match: item_name in `self.publish_items_to_include` - preserves original case sensitivity
      - Case-Insensitive Match: `item_name.lower() in normalized_include_set` - handles case variations
      - Logical OR: Either match type triggers inclusion, providing flexible user experience
    - Skip Logic Implementation:
      - Purpose: Prevents publishing items not in the include list
      - Logging: Provides clear feedback about which items are being skipped
      - Early Return: Exits method immediately to avoid unnecessary processing

### 3. Core Implementation in `publish.py`
  - **Modified Function Signature:**
    - Added items_to_include: Optional[List[str]] = None parameter to publish_all_items() method
  - **Additional Documentation**
    - Added comprehensive parameter documentation for `items_to_include`
    - Included practical usage examples showing selective publishing scenarios
  - **Filter Implementation:**
    Configures the workspace object with the inclusion filter and provides informational logging